### PR TITLE
Make ZAPBench storage paths configurable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,5 @@
     },
     "python.testing.pytestArgs": [
         "."
-    ],
-    "python.defaultInterpreterPath": "/home/sebastian/git/zapbench/.pixi/envs/default/bin/python"
+    ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 
 ## Time-series training and inference contract
 
-- Treat `process_janelia/train.sh`, `process_janelia/train_zapbench.sh`, `process_janelia/pre-train.sh`, and `process_janelia/infer.sh` as the source of truth for the current time-series invocation pattern. Their `/home/sebastian`, `/mnt/storage`, and `CUDA_VISIBLE_DEVICES=7` values describe the machine on which they were written; do not copy those machine-specific values to RunPod.
+- Treat `process_janelia/train.sh`, `process_janelia/train_zapbench.sh`, `process_janelia/pre-train.sh`, and `process_janelia/infer.sh` as the source of truth for the current time-series invocation pattern. They use repository-relative entry points and require an explicit `OUTPUT_ROOT` for their local batch layout. They do not replace the literal one-run commands in an approved RunPod run card; select a GPU externally only when the exact run requires it.
 - Run the time-series entry points from the repository root. Training uses `zapbench/ts_forecasting/main_train.py` with a model config and concise overrides; inference uses `zapbench/ts_forecasting/main_infer.py`, with the completed training directory supplied as `exp_workdir`:
 
   ```bash

--- a/nbs/1.1-explore-janelia.ipynb
+++ b/nbs/1.1-explore-janelia.ipynb
@@ -332,8 +332,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PATH_LOAD = \"/Users/s/vault/neural_data/janelia/\"\n",
-    "PATH_STORE = \"/Users/s/vault/neural_data/janelia/ts_files\"\n",
+    "PATH_LOAD = PATH\n",
+    "PATH_STORE = f\"{PATH}/ts_files\"\n",
     "\n",
     "# save_janelia(14)"
    ]

--- a/nbs/3.0-harmonise-dataset.ipynb
+++ b/nbs/3.0-harmonise-dataset.ipynb
@@ -15,7 +15,9 @@
     "import matplotlib.pyplot as plt\n",
     "import scienceplots\n",
     "import tensorstore as ts\n",
+    "from dotenv import load_dotenv\n",
     "\n",
+    "load_dotenv()\n",
     "plt.style.use(['science'])"
    ]
   },
@@ -283,7 +285,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PATH = \"/home/sebastian/data/janelia\"\n",
+    "PATH = os.environ[\"ROOT_PATH\"]\n",
     "n_stimulus_encodings = 16\n",
     "all_condition_names = ['spontaneous', 'taxis', 'dark-taxis', 'dark', 'opt_response', 'looming']\n",
     "condition_map = dict()\n",
@@ -322,7 +324,7 @@
     }
    ],
    "source": [
-    "PATH = \"/home/sebastian/data/janelia\"\n",
+    "PATH = os.environ[\"ROOT_PATH\"]\n",
     "subject_id_list = [1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17]\n",
     "x_jan_n_list = []\n",
     "for subject_id in subject_id_list:\n",
@@ -661,7 +663,7 @@
     }
    ],
    "source": [
-    "PATH = \"/home/sebastian/data/janelia\"\n",
+    "PATH = os.environ[\"ROOT_PATH\"]\n",
     "subject_id_list = [1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17]\n",
     "n_stimulus_encodings = 16\n",
     "\n",
@@ -728,7 +730,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PATH_STORE = \"/home/sebastian/data/janelia/ts_files\"\n",
+    "PATH_STORE = f\"{os.environ['ROOT_PATH']}/ts_files\"\n",
     "SUBJECT_ID_LIST = [1, 2, 3, 4, 5, 6, 7, 12, 13, 14, 15, 16, 17]\n",
     "\n",
     "subject_id = SUBJECT_ID_LIST[0]\n",
@@ -824,7 +826,7 @@
     "import numpy as np\n",
     "import scipy\n",
     "\n",
-    "reference_anat = scipy.io.loadmat('/home/sebastian/data/janelia/Additional_mat_files/ReferenceBrain.mat')\n",
+    "reference_anat = scipy.io.loadmat(f\"{os.environ['ROOT_PATH']}/Additional_mat_files/ReferenceBrain.mat\")\n",
     "x = reference_anat['anat_stack_norm']\n",
     "grid = pv.wrap(x)\n",
     "grid.spacing = [1.0, 1.0, 2.0]\n",
@@ -895,7 +897,7 @@
     "import numpy as np\n",
     "import scipy\n",
     "\n",
-    "reference_anat = scipy.io.loadmat('/home/sebastian/data/janelia/Additional_mat_files/ReferenceBrain.mat')\n",
+    "reference_anat = scipy.io.loadmat(f\"{os.environ['ROOT_PATH']}/Additional_mat_files/ReferenceBrain.mat\")\n",
     "x = reference_anat['anat_stack_norm']\n",
     "grid = pv.wrap(x)\n",
     "grid.spacing = [1.0, 1.0, 2.0]\n",

--- a/nbs/4.0-inference_gpu.ipynb
+++ b/nbs/4.0-inference_gpu.ipynb
@@ -38,6 +38,7 @@
     "load_dotenv()\n",
     "PATH = os.getenv(\"ROOT_PATH\")\n",
     "LOG_PATH = os.getenv(\"LOG_PATH\")\n",
+    "INFERENCE_ROOT = os.environ[\"INFERENCE_ROOT\"]\n",
     "\n",
     "def format_ax(ax):\n",
     "  for spine in ax.spines.values():\n",
@@ -898,7 +899,7 @@
     "import glob\n",
     "from zapbench.ts_forecasting import util\n",
     "\n",
-    "path_to_inference = glob.glob(\"/mnt/storage/misc/zapbench/inference/n_steps_4/mean/**/\", recursive=True)[-1]\n",
+    "path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_4/mean/**/\", recursive=True)[-1]\n",
     "df = util.get_per_step_metrics_from_directory(path_to_inference,metric='MAE')\n",
     "df.sort_values('condition')"
    ]

--- a/nbs/4.2-inference_eval_gpu.ipynb
+++ b/nbs/4.2-inference_eval_gpu.ipynb
@@ -7,10 +7,15 @@
    "outputs": [],
    "source": [
     "import glob\n",
+    "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import scienceplots\n",
+    "from dotenv import load_dotenv\n",
     "from zapbench.ts_forecasting import util\n",
+    "\n",
+    "load_dotenv()\n",
+    "INFERENCE_ROOT = os.environ[\"INFERENCE_ROOT\"]\n",
     "\n",
     "plt.style.use(\"science\")\n",
     "\n",
@@ -43,7 +48,7 @@
     "  for model_name in model_names:\n",
     "    performance_dict[subject_id][model_name] = {}\n",
     "    for step_ahead in steps_ahead:\n",
-    "      path_to_inference = glob.glob(f\"/mnt/storage/misc/zapbench/inference/n_steps_4/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
+    "      path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_4/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
     "      df = util.get_per_step_metrics_from_directory(path_to_inference, metric='MAE')\n",
     "      performance_dict[subject_id][model_name][step_ahead] = df['MAE'][df['steps_ahead'] == step_ahead].mean()"
    ]
@@ -88,7 +93,7 @@
     "  for model_name in model_names:\n",
     "    performance_dict[subject_id][model_name] = {}\n",
     "    for step_ahead in steps_ahead:\n",
-    "      path_to_inference = glob.glob(f\"/mnt/storage/misc/zapbench/inference/n_steps_4/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
+    "      path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_4/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
     "      # print(path_to_inference)\n",
     "      df = util.get_per_step_metrics_from_directory(path_to_inference, metric='MAE')\n",
     "      performance_dict[subject_id][model_name][step_ahead] = df['MAE'][df['steps_ahead'] == step_ahead].mean()"
@@ -298,7 +303,7 @@
     "    performance_dict[n][model_name] = {}\n",
     "    for subject_id in subject_ids:\n",
     "      subject_name = \"subject_\" + subject_id if subject_id != \"zapbench\" and subject_id != \"janelia_pretrain\" else subject_id\n",
-    "      path_to_inference = glob.glob(f\"/mnt/storage/misc/zapbench/inference/n_steps_{n}/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
+    "      path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_{n}/{model_name}/{subject_name}/**/\", recursive=True)[-1]\n",
     "      df = util.get_per_step_metrics_from_directory(path_to_inference, metric='MAE')\n",
     "      avg_mae = df['MAE'][31].mean()\n",
     "      performance_dict[n][model_name][subject_id] = avg_mae"

--- a/nbs/5.0-construct_pretraining_dataset.ipynb
+++ b/nbs/5.0-construct_pretraining_dataset.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PATH_STORE = \"/mnt/storage/misc/zapbench/data/ts_files\"\n",
+    "PATH_STORE = f\"{PATH}/ts_files\"\n",
     "spec = {\n",
     "    'driver': 'zarr3',\n",
     "    'kvstore': {'driver': 'file', 'path': f'{PATH_STORE}/janelia_pretrain_traces.zarr'},\n",
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PATH_STORE = \"/mnt/storage/misc/zapbench/data/ts_files\"\n",
+    "PATH_STORE = f\"{PATH}/ts_files\"\n",
     "spec = {\n",
     "    'driver': 'zarr3',\n",
     "    'kvstore': {'driver': 'file', 'path': f'{PATH_STORE}/janelia_pretrain_stimuli.zarr'},\n",

--- a/nbs/5.1-inference_across_subjects_gpu.ipynb
+++ b/nbs/5.1-inference_across_subjects_gpu.ipynb
@@ -40,6 +40,7 @@
     "load_dotenv()\n",
     "PATH = os.getenv(\"ROOT_PATH\")\n",
     "LOG_PATH = os.getenv(\"LOG_PATH\")\n",
+    "INFERENCE_ROOT = os.environ[\"INFERENCE_ROOT\"]\n",
     "\n",
     "logger = logging.getLogger(__name__)  # Create a logger for this module\n",
     "logger.setLevel(logging.INFO)\n",
@@ -287,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = f\"/mnt/storage/misc/zapbench/inference/n_steps_4/timemix/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
+    "path = f\"{INFERENCE_ROOT}/n_steps_4/timemix/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
     "with open(path, \"w\") as f:\n",
     "    json.dump(convert_to_serializable(all_infer_metrics), f)"
    ]
@@ -320,7 +321,7 @@
    "source": [
     "mae_matrix = []\n",
     "for train_subject_name in infer_subject_names:\n",
-    "  path = f\"/mnt/storage/misc/zapbench/inference/n_steps_4/timemix/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
+    "  path = f\"{INFERENCE_ROOT}/n_steps_4/timemix/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
     "  with open(path.format(train_subject_name=train_subject_name), \"r\") as f:\n",
     "    all_infer_metrics_loaded = json.load(f)\n",
     "    all_maes = []\n",
@@ -657,7 +658,7 @@
     "import glob\n",
     "from zapbench.ts_forecasting import util\n",
     "\n",
-    "path_to_inference = glob.glob(\"/mnt/storage/misc/zapbench/inference/n_steps_4/mean/**/\", recursive=True)[-1]\n",
+    "path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_4/mean/**/\", recursive=True)[-1]\n",
     "df = util.get_per_step_metrics_from_directory(path_to_inference,metric='MAE')\n",
     "df.sort_values('condition')"
    ]

--- a/nbs/5.2-inference_pretraining_gpu.ipynb
+++ b/nbs/5.2-inference_pretraining_gpu.ipynb
@@ -40,6 +40,7 @@
     "load_dotenv()\n",
     "PATH = os.getenv(\"ROOT_PATH\")\n",
     "LOG_PATH = os.getenv(\"LOG_PATH\")\n",
+    "INFERENCE_ROOT = os.environ[\"INFERENCE_ROOT\"]\n",
     "\n",
     "logger = logging.getLogger(__name__)  # Create a logger for this module\n",
     "logger.setLevel(logging.INFO)\n",
@@ -287,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = f\"/mnt/storage/misc/zapbench/inference/n_steps_{exp_config.timesteps_input}/mean/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
+    "path = f\"{INFERENCE_ROOT}/n_steps_{exp_config.timesteps_input}/mean/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
     "with open(path, \"w\") as f:\n",
     "    json.dump(convert_to_serializable(all_infer_metrics), f)"
    ]
@@ -336,7 +337,7 @@
     "train_subject_name = \"janelia_pretrain\"\n",
     "for n_steps in [4, 32]:\n",
     "  for model in [\"mean\", \"linear\", \"timemix\"]:\n",
-    "    path = f\"/mnt/storage/misc/zapbench/inference/n_steps_{n_steps}/{model}/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
+    "    path = f\"{INFERENCE_ROOT}/n_steps_{n_steps}/{model}/cross_subject_infer_metrics/all_infer_metrics_{train_subject_name}.json\"\n",
     "    with open(path.format(train_subject_name=train_subject_name), \"r\") as f:\n",
     "      all_infer_metrics_loaded = json.load(f)\n",
     "      all_maes = []\n",
@@ -676,7 +677,7 @@
     "import glob\n",
     "from zapbench.ts_forecasting import util\n",
     "\n",
-    "path_to_inference = glob.glob(\"/mnt/storage/misc/zapbench/inference/n_steps_4/mean/**/\", recursive=True)[-1]\n",
+    "path_to_inference = glob.glob(f\"{INFERENCE_ROOT}/n_steps_4/mean/**/\", recursive=True)[-1]\n",
     "df = util.get_per_step_metrics_from_directory(path_to_inference,metric='MAE')\n",
     "df.sort_values('condition')"
    ]

--- a/nbs/codex-exp-1.ipynb
+++ b/nbs/codex-exp-1.ipynb
@@ -34,6 +34,7 @@
     "import scipy.io\n",
     "import tensorstore as ts\n",
     "import torch\n",
+    "from dotenv import load_dotenv\n",
     "from sbi.inference import NPE\n",
     "from sbi.utils import BoxUniform\n",
     "from torch.utils.tensorboard import SummaryWriter\n",
@@ -43,7 +44,8 @@
     "plt.style.use(\"science\")\n",
     "plt.rcParams[\"text.usetex\"] = False\n",
     "\n",
-    "PATH = \"/Users/s/vault/neural_data/janelia\"\n",
+    "load_dotenv()\n",
+    "PATH = os.environ[\"ROOT_PATH\"]\n",
     "_ = torch.manual_seed(0)"
    ]
   },

--- a/process_janelia/README.md
+++ b/process_janelia/README.md
@@ -10,10 +10,10 @@ current dataset-aware time-series code is trained and evaluated. In particular:
 - `infer.sh` passes each completed training directory to inference through
   `exp_workdir` and writes results to a separate inference directory.
 
-The scripts were written for a machine with repositories under
-`/home/sebastian`, storage under `/mnt/storage`, and a usable GPU at index 7.
-Those literal paths and the GPU index are historical. They are not portable
-RunPod commands and should not be executed there verbatim.
+The scripts use repository-relative entry points and require `OUTPUT_ROOT` to
+name the parent directory beneath which they create their existing `training/`
+and `inference/` batch layout. Set `CUDA_VISIBLE_DEVICES` externally only when
+the selected host and run require it; the scripts do not choose a GPU.
 
 ## Minimal command pattern
 
@@ -49,8 +49,23 @@ for data paths and shapes; check it before running. For the `subject_NN`
 entries, set `ROOT_PATH` to the directory containing the required `ts_files/`
 subdirectory.
 
+`download_janelia.sh` also writes the raw Janelia files beneath `ROOT_PATH`,
+and `store_janelia.py` writes the converted stores beneath its `ts_files/`
+child. For example, a local batch invocation from the repository root is:
+
+```bash
+ROOT_PATH=/path/to/janelia-data \
+OUTPUT_ROOT=/path/to/zapbench-outputs \
+bash process_janelia/pre-train.sh
+```
+
+The historical inference-analysis notebooks that read the old multi-run batch
+layout use `INFERENCE_ROOT` for the directory whose children are `n_steps_*`.
+That variable only makes those archived analyses relocatable; it does not
+define the layout for new runs.
+
 For RunPod experiments, replace `<persistent-run-directory>` with the approved
 path under `/space/vault/zapbench/experiments/<experiment-id>/runs/<run-id>` and
 put the resulting literal commands in the run card. Use one command for the
-atomic run instead of modifying these historical batch scripts or adding a new
+atomic run instead of invoking a multi-run batch script or adding a new
 launcher.

--- a/process_janelia/bash.txt
+++ b/process_janelia/bash.txt
@@ -1,32 +1,32 @@
-nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu,utilization.memory --format=csv
+# Illustrative command fragments. Replace the path placeholders with the exact
+# persistent run directory selected for the run.
 
 
 TRAIN
 
-CUDA_VISIBLE_DEVICES=7 python zapbench/ts_forecasting/main_train.py \
+python zapbench/ts_forecasting/main_train.py \
 --config zapbench/ts_forecasting/configs/linear.py:dataset_name='janelia_pretrain',runlocal=False,timesteps_input=32 \
---workdir /mnt/storage/misc/exp/linear/janelia_pretrain
+--workdir <persistent-run-directory>/training
 
 
 
 INFER
 
-CUDA_VISIBLE_DEVICES=7 python zapbench/ts_forecasting/main_infer.py \
---config zapbench/ts_forecasting/configs/infer.py:exp_workdir=/mnt/storage/misc/zapbench/training/n_steps_4/mean/zapbench \
---workdir /mnt/storage/misc/zapbench/inference/n_steps_4/mean/zapbench
+python zapbench/ts_forecasting/main_infer.py \
+--config zapbench/ts_forecasting/configs/infer.py:exp_workdir=<persistent-run-directory>/training \
+--workdir <persistent-run-directory>/inference
 
 
 
-CUDA_VISIBLE_DEVICES=7 python /home/sebastian/git/zapbench/zapbench/ts_forecasting/main_infer.py \
---config /home/sebastian/git/zapbench/zapbench/ts_forecasting/configs/infer.py:exp_workdir=/mnt/storage/misc/exp/timemix/subject_01 \
---workdir /mnt/storage/misc/zapbench/inference/n_steps_32/timemix/subject_01
+python zapbench/ts_forecasting/main_infer.py \
+--config zapbench/ts_forecasting/configs/infer.py:exp_workdir=<persistent-run-directory>/training \
+--workdir <persistent-run-directory>/inference
 
 
 
-CUDA_VISIBLE_DEVICES=7 python zapbench/ts_forecasting/main_train.py \
+python zapbench/ts_forecasting/main_train.py \
 --config zapbench/ts_forecasting/configs/mean.py:dataset_name='janelia_pretrain',runlocal=False,timesteps_input=4 \
---workdir /mnt/storage/misc/zapbench/training/n_steps_4/mean/janelia_pretrain
-
+--workdir <persistent-run-directory>/training
 
 
 

--- a/process_janelia/download_janelia.sh
+++ b/process_janelia/download_janelia.sh
@@ -6,7 +6,8 @@ FILE_IDS=(
     13485524 13488344 13488416 14298635 14299349
 )
 BASE_URL="https://janelia.figshare.com/ndownloader/files"
-DOWNLOAD_DIR="/home/sebastian/data/janelia"
+: "${ROOT_PATH:?Set ROOT_PATH to the directory that will contain the Janelia data and ts_files/}"
+DOWNLOAD_DIR="${ROOT_PATH}"
 
 # Create download directory if it doesn't exist
 mkdir -p "$DOWNLOAD_DIR"

--- a/process_janelia/infer.sh
+++ b/process_janelia/infer.sh
@@ -5,20 +5,23 @@
 MODELS=("mean" "linear" "timemix")
 SUBJECTS=("janelia_pretrain" "zapbench")
 N_STEPS=(4 32)
+: "${OUTPUT_ROOT:?Set OUTPUT_ROOT to the parent directory for training and inference outputs}"
+: "${ROOT_PATH:?Set ROOT_PATH to the directory whose ts_files/ contains the registered stores}"
+
 for MODEL_NAME in "${MODELS[@]}"; do
     for SUBJECT_ID in "${SUBJECTS[@]}"; do
         for STEP in "${N_STEPS[@]}"; do
-            TRAIN_WORKDIR="/mnt/storage/misc/zapbench/training/n_steps_${STEP}/${MODEL_NAME}/${SUBJECT_ID}"
-            INFER_WORKDIR="/mnt/storage/misc/zapbench/inference/n_steps_${STEP}/${MODEL_NAME}/${SUBJECT_ID}"
+            TRAIN_WORKDIR="${OUTPUT_ROOT}/training/n_steps_${STEP}/${MODEL_NAME}/${SUBJECT_ID}"
+            INFER_WORKDIR="${OUTPUT_ROOT}/inference/n_steps_${STEP}/${MODEL_NAME}/${SUBJECT_ID}"
             if [ -d "$INFER_WORKDIR" ]; then
                 echo "skipping inference ${MODEL_NAME}; subject ${SUBJECT_ID} - directory already exists: $INFER_WORKDIR"
             else
                 echo "running inference for ${MODEL_NAME}; ${SUBJECT_ID}..."
                 echo "infer workdir ${INFER_WORKDIR}"
                 echo "train workdir ${TRAIN_WORKDIR}"
-                if ! CUDA_VISIBLE_DEVICES=7 python /home/sebastian/git/zapbench/zapbench/ts_forecasting/main_infer.py \
-                    --config /home/sebastian/git/zapbench/zapbench/ts_forecasting/configs/infer.py:exp_workdir=$TRAIN_WORKDIR \
-                    --workdir $INFER_WORKDIR; then
+                if ! python zapbench/ts_forecasting/main_infer.py \
+                    --config "zapbench/ts_forecasting/configs/infer.py:exp_workdir=${TRAIN_WORKDIR}" \
+                    --workdir "$INFER_WORKDIR"; then
                     echo "ERROR: inference failed for ${MODEL_NAME}; subject ${SUBJECT_ID}; continuing to next..."
                     continue
                 fi

--- a/process_janelia/pre-train.sh
+++ b/process_janelia/pre-train.sh
@@ -2,13 +2,15 @@
 
 MODELS=("linear" "timemix")
 TIMESTEPS_INPUT=(4 32)
+: "${OUTPUT_ROOT:?Set OUTPUT_ROOT to the parent directory for training outputs}"
+: "${ROOT_PATH:?Set ROOT_PATH to the directory whose ts_files/ contains the registered stores}"
 
 for MODEL_NAME in "${MODELS[@]}"; do
     for T in "${TIMESTEPS_INPUT[@]}"; do
         echo "pre-training ${MODEL_NAME}..."
-        TRAIN_WORKDIR="/mnt/storage/misc/zapbench/training/n_steps_${T}/${MODEL_NAME}/janelia_pretrain"
-        if ! CUDA_VISIBLE_DEVICES=7 python /home/sebastian/git/zapbench/zapbench/ts_forecasting/main_train.py \
-            --config /home/sebastian/git/zapbench/zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=janelia_pretrain,runlocal=False,timesteps_input=$T \
+        TRAIN_WORKDIR="${OUTPUT_ROOT}/training/n_steps_${T}/${MODEL_NAME}/janelia_pretrain"
+        if ! python zapbench/ts_forecasting/main_train.py \
+            --config "zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=janelia_pretrain,runlocal=False,timesteps_input=${T}" \
             --workdir "$TRAIN_WORKDIR"; then
             echo "ERROR: pre-training failed for ${MODEL_NAME}; continuing"
             continue

--- a/process_janelia/store_janelia.py
+++ b/process_janelia/store_janelia.py
@@ -5,12 +5,11 @@ import h5py
 import numpy as np
 import scipy.io
 from dotenv import load_dotenv
-import os
 
 import tensorstore as ts
 
 load_dotenv()
-PATH = os.getenv("ROOT_PATH")
+PATH = os.environ["ROOT_PATH"]
 GIT_PATH = os.getenv("GIT_PATH")
 PATH_JANELIA = PATH
 PATH_STORE = f"{PATH}/ts_files"

--- a/process_janelia/train.sh
+++ b/process_janelia/train.sh
@@ -4,17 +4,19 @@
 # SUBJECTS=(1 6 15 17)
 MODELS=("mean")
 SUBJECTS=(1 2 3 4 5 6 7 12 13 14 15 16 17)
+: "${OUTPUT_ROOT:?Set OUTPUT_ROOT to the parent directory for training outputs}"
+: "${ROOT_PATH:?Set ROOT_PATH to the directory whose ts_files/ contains the registered stores}"
 
 for MODEL_NAME in "${MODELS[@]}"; do
     for SUBJECT_ID in "${SUBJECTS[@]}"; do
         SUBJECT_ID_PADDED=$(printf "%02d" $SUBJECT_ID)
-        TRAIN_WORKDIR="/mnt/storage/misc/exp/${MODEL_NAME}/subject_${SUBJECT_ID_PADDED}"
+        TRAIN_WORKDIR="${OUTPUT_ROOT}/training/n_steps_32/${MODEL_NAME}/subject_${SUBJECT_ID_PADDED}"
         if [ -d "$TRAIN_WORKDIR" ]; then
             echo "Skipping training ${MODEL_NAME}; subject ${SUBJECT_ID_PADDED} - directory already exists: $TRAIN_WORKDIR"
         else
             echo "Training ${MODEL_NAME}; subject ${SUBJECT_ID_PADDED}..."
-            if ! CUDA_VISIBLE_DEVICES=7 python /home/sebastian/git/zapbench/zapbench/ts_forecasting/main_train.py \
-                --config /home/sebastian/git/zapbench/zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=subject_${SUBJECT_ID_PADDED},runlocal=False,timesteps_input=32 \
+            if ! python zapbench/ts_forecasting/main_train.py \
+                --config "zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=subject_${SUBJECT_ID_PADDED},runlocal=False,timesteps_input=32" \
                 --workdir "$TRAIN_WORKDIR"; then
                 echo "ERROR: Training failed for ${MODEL_NAME}; subject ${SUBJECT_ID_PADDED}. Continuing to next..."
                 continue

--- a/process_janelia/train_zapbench.sh
+++ b/process_janelia/train_zapbench.sh
@@ -2,13 +2,14 @@
 
 MODELS=("mean" "linear" "timemix" "tsmixer" "tide")
 TIMESTEPS_INPUT=(4 32)
+: "${OUTPUT_ROOT:?Set OUTPUT_ROOT to the parent directory for training outputs}"
 
 for MODEL_NAME in "${MODELS[@]}"; do
     for T in "${TIMESTEPS_INPUT[@]}"; do
         echo "training ${MODEL_NAME}..."
-        TRAIN_WORKDIR="/mnt/storage/misc/zapbench/training/n_steps_${T}/${MODEL_NAME}/zapbench"
-        if ! CUDA_VISIBLE_DEVICES=7 python /home/sebastian/git/zapbench/zapbench/ts_forecasting/main_train.py \
-            --config /home/sebastian/git/zapbench/zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=240930_traces,runlocal=False,timesteps_input=$T \
+        TRAIN_WORKDIR="${OUTPUT_ROOT}/training/n_steps_${T}/${MODEL_NAME}/zapbench"
+        if ! python zapbench/ts_forecasting/main_train.py \
+            --config "zapbench/ts_forecasting/configs/${MODEL_NAME}.py:dataset_name=240930_traces,runlocal=False,timesteps_input=${T}" \
             --workdir "$TRAIN_WORKDIR"; then
             echo "ERROR: training failed for ${MODEL_NAME}; continuing"
             continue

--- a/zapbench/constants.py
+++ b/zapbench/constants.py
@@ -993,7 +993,9 @@ DATASET_CONFIGS = {
         'covariate_series_name': 'janelia_pretrain_stimuli_features',
         'specs': {
             'janelia_pretrain': {
-                'kvstore': f'file:///mnt/storage/misc/zapbench/data/ts_files/janelia_pretrain_traces.zarr',
+                'kvstore': (
+                    f'file:///{ROOT_PATH}/ts_files/janelia_pretrain_traces.zarr'
+                ),
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[37247], 50000],
@@ -1004,7 +1006,9 @@ DATASET_CONFIGS = {
         },
         'covariate_specs': {
             'janelia_pretrain_stimuli_features': {
-                'kvstore': f'file:///mnt/storage/misc/zapbench/data/ts_files/janelia_pretrain_stimuli.zarr',
+                'kvstore': (
+                    f'file:///{ROOT_PATH}/ts_files/janelia_pretrain_stimuli.zarr'
+                ),
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[37247], 16],

--- a/zapbench/constants.py
+++ b/zapbench/constants.py
@@ -154,7 +154,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_01': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_01_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_01_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -167,7 +167,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_01_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_01_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_01_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -177,7 +177,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_01_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_01_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_01_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[2880], 5],
@@ -190,7 +190,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_01': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_01_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_01_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -214,7 +214,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_02': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_02_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_02_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -227,7 +227,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_02_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_02_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_02_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -237,7 +237,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_02_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_02_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_02_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[3520], 5],
@@ -250,7 +250,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_02': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_02_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_02_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -274,7 +274,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_03': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_03_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_03_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -287,7 +287,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_03_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_03_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_03_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -297,7 +297,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_03_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_03_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_03_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[2560], 5],
@@ -310,7 +310,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_03': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_03_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_03_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -334,7 +334,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_04': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_04_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_04_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -347,7 +347,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_04_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_04_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_04_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -357,7 +357,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_04_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_04_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_04_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[2880], 5],
@@ -370,7 +370,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_04': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_04_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_04_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -394,7 +394,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_05': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_05_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_05_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -407,7 +407,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_05_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_05_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_05_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -417,7 +417,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_05_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_05_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_05_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[2880], 5],
@@ -430,7 +430,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_05': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_05_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_05_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -454,7 +454,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_06': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_06_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_06_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -467,7 +467,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_06_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_06_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_06_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -477,7 +477,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_06_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_06_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_06_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[3780], 5],
@@ -490,7 +490,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_06': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_06_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_06_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -514,7 +514,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_07': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_07_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_07_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -527,7 +527,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_07_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_07_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_07_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -537,7 +537,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_07_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_07_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_07_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[1650], 5],
@@ -550,7 +550,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_07': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_07_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_07_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -586,7 +586,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_12': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_12_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_12_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -599,7 +599,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_12_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_12_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_12_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -609,7 +609,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_12_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_12_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_12_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[6140], 5],
@@ -622,7 +622,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_12': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_12_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_12_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -658,7 +658,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_13': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_13_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_13_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -671,7 +671,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_13_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_13_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_13_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -681,7 +681,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_13_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_13_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_13_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[4840], 5],
@@ -694,7 +694,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_13': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_13_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_13_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -730,7 +730,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_14': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_14_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_14_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -743,7 +743,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_14_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_14_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_14_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -753,7 +753,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_14_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_14_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_14_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[3890], 5],
@@ -766,7 +766,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_14': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_14_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_14_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -802,7 +802,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_15': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_15_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_15_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -815,7 +815,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_15_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_15_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_15_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -825,7 +825,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_15_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_15_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_15_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[4880], 5],
@@ -838,7 +838,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_15': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_15_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_15_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -862,7 +862,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_16': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_16_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_16_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -875,7 +875,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_16_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_16_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_16_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -885,7 +885,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_16_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_16_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_16_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[1877], 5],
@@ -898,7 +898,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_16': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_16_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_16_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -934,7 +934,7 @@ DATASET_CONFIGS = {
         'specs': {
             'subject_17': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_17_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_17_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -947,7 +947,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'subject_17_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_17_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_17_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -957,7 +957,7 @@ DATASET_CONFIGS = {
                 },
             },
             'subject_17_behavioral_covariates': {
-                'kvstore': f'file:///{ROOT_PATH}/ts_files/subject_17_behavioral_covariates.zarr',
+                'kvstore': f'file://{ROOT_PATH}/ts_files/subject_17_behavioral_covariates.zarr',
                 'driver': 'zarr3',
                 'transform': {
                     'input_exclusive_max': [[5554], 5],
@@ -970,7 +970,7 @@ DATASET_CONFIGS = {
         'position_embedding_specs': {
             'subject_17': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/subject_17_coordinates.zarr'
+                    f'file://{ROOT_PATH}/ts_files/subject_17_coordinates.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -994,7 +994,7 @@ DATASET_CONFIGS = {
         'specs': {
             'janelia_pretrain': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/janelia_pretrain_traces.zarr'
+                    f'file://{ROOT_PATH}/ts_files/janelia_pretrain_traces.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {
@@ -1007,7 +1007,7 @@ DATASET_CONFIGS = {
         'covariate_specs': {
             'janelia_pretrain_stimuli_features': {
                 'kvstore': (
-                    f'file:///{ROOT_PATH}/ts_files/janelia_pretrain_stimuli.zarr'
+                    f'file://{ROOT_PATH}/ts_files/janelia_pretrain_stimuli.zarr'
                 ),
                 'driver': 'zarr3',
                 'transform': {

--- a/zapbench/constants_test.py
+++ b/zapbench/constants_test.py
@@ -1,0 +1,54 @@
+# Copyright 2025 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dataset constants."""
+
+import os
+import runpy
+from unittest import mock
+
+from absl.testing import absltest
+from zapbench import constants
+
+
+class ConstantsTest(absltest.TestCase):
+
+  def test_local_file_uris_use_absolute_root(self):
+    root_path = '/space/vault/zapbench/data/example'
+    with mock.patch.dict(os.environ, {'ROOT_PATH': root_path}):
+      registry = runpy.run_path(constants.__file__)['DATASET_CONFIGS']
+
+    file_uris = []
+
+    def collect_file_uris(value):
+      if isinstance(value, str) and value.startswith('file://'):
+        file_uris.append(value)
+      elif isinstance(value, dict):
+        for child in value.values():
+          collect_file_uris(child)
+      elif isinstance(value, (list, tuple)):
+        for child in value:
+          collect_file_uris(child)
+
+    collect_file_uris(registry)
+    self.assertTrue(file_uris)
+
+    expected_prefix = f'file://{root_path}/ts_files/'
+    for uri in file_uris:
+      self.assertTrue(uri.startswith(expected_prefix), uri)
+      self.assertNotIn('file:////space/', uri)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/zapbench/ts_forecasting/README.md
+++ b/zapbench/ts_forecasting/README.md
@@ -23,10 +23,10 @@ shapes, conditions, timeseries, and covariates. Local Janelia entries resolve
 their `ts_files/` paths relative to `ROOT_PATH`.
 
 The scripts under `process_janelia/` are the operational reference for the
-current time-series training and inference command structure. Their absolute
-paths and GPU index are specific to the machine on which they were written;
-replace those values for the current host rather than running the scripts
-verbatim. See `process_janelia/README.md` for concise templates.
+current time-series training and inference command structure. They use
+repository-relative entry points and an explicit output root rather than a
+machine-specific storage mount. See `process_janelia/README.md` for concise
+templates.
 
 ## Training
 


### PR DESCRIPTION
**Summary**
- Replace machine-specific storage and output paths with explicit environment-controlled roots and repository-relative commands.
- Correct local TensorStore URI construction for absolute ROOT_PATH values such as /space/vault/...
- Update Janelia scripts, documentation, and executable notebook cells to use the portable contracts.

**Verification**
- Absolute-root registry regression test
- Shell syntax, Python AST, notebook JSON, and whitespace checks

**Stack**
1. paths
2. poco-covariate-specs
3. tide-poco-model
4. tide-poco-config
5. tide-poco-shapes