### PR TITLE
Add opt-in POCO embeddings to TiDE config

### DIFF
--- a/zapbench/ts_forecasting/configs/tide.py
+++ b/zapbench/ts_forecasting/configs/tide.py
@@ -35,6 +35,7 @@ _ARGS = immutabledict.immutabledict({
     'timesteps_input': 32,
     'runlocal': False,
     'dataset_name': 'subject_01',
+    'use_poco_embeddings': False,
 })
 
 _EXPERIMENTS = {


### PR DESCRIPTION
**Summary**
- Add the TiDE-local use_poco_embeddings flag.
- Default the flag to false so current runs retain their existing behavior.
- Support the existing config override syntax without exposing the option to unrelated models.

**Verification**
- Default false and override true parse through ml_collections
- One-line, one-file diff

**Stack base**
tide-poco-model