### PR TITLE
Wire POCO origin embeddings through TiDE pipelines

### DIFF
--- a/zapbench/ts_forecasting/configs/common.py
+++ b/zapbench/ts_forecasting/configs/common.py
@@ -32,11 +32,12 @@ def _get_specs(
     covariate_series: str,
     soma_ids: Sequence[int],
     dataset_name: str,
+    poco_embeddings_series: str | None = None,
 ) -> Sequence[dict[str, Any]]:
   """Get specs with dataset-aware context."""
   specs = []
   for condition in conditions:
-    specs.append({
+    condition_specs = {
         'timeseries': data_utils.adjust_spec_for_condition_and_split(
             spec=data_utils.get_spec(
                 timeseries, soma_ids, dataset_name=dataset_name
@@ -55,7 +56,20 @@ def _get_specs(
             num_timesteps_context=num_timesteps_context,
             dataset_name=dataset_name,
         ).to_json(),
-    })
+    }
+    if poco_embeddings_series is not None:
+      condition_specs['poco_embeddings'] = (
+          data_utils.adjust_spec_for_condition_and_split(
+              spec=data_utils.get_covariate_spec(
+                  poco_embeddings_series, dataset_name=dataset_name
+              ),
+              condition=condition,
+              split=split,
+              num_timesteps_context=num_timesteps_context,
+              dataset_name=dataset_name,
+          ).to_json()
+      )
+    specs.append(condition_specs)
   return specs
 
 
@@ -120,6 +134,7 @@ def get_config(
     runlocal: bool = False,
     timeseries: str = None,
     covariate_series: str = None,
+    poco_embeddings_series: str = None,
     val_ckpt_every_steps: int = 250,
     log_loss_every_steps: int = 100,
     seed: int | tuple[int, int] | None = -1,
@@ -139,6 +154,8 @@ def get_config(
     runlocal: Whether running locally or remotely.
     timeseries: Name of the timeseries in dataset specs. If None, uses dataset default.
     covariate_series: Name of the covariates in dataset covariate specs. If None, uses dataset default.
+    poco_embeddings_series: Optional POCO embedding series to expose as a
+      separate forecast-origin model input.
     val_ckpt_every_steps: Frequency of validation/checkpointing.
     log_loss_every_steps: Frequency of logging loss.
     seed: Optional random seed. Uses a randomly generated seed if None or
@@ -248,6 +265,7 @@ def get_config(
       covariate_series=c.covariate_series,
       soma_ids=soma_ids,
       dataset_name=dataset_name,
+      poco_embeddings_series=poco_embeddings_series,
   )
 
   # Validation
@@ -259,6 +277,7 @@ def get_config(
       covariate_series=c.covariate_series,
       soma_ids=soma_ids,
       dataset_name=dataset_name,
+      poco_embeddings_series=poco_embeddings_series,
   )
   c.num_val_steps = -1  # = 0 to disable, = -1 to iterate over val batches
   c.val_pad_last_batch = False
@@ -275,6 +294,10 @@ def get_config(
           c.covariate_series, dataset_name=dataset_name
       ).to_json(),
   }
+  if poco_embeddings_series is not None:
+    c.infer_spec['poco_embeddings'] = data_utils.get_covariate_spec(
+        poco_embeddings_series, dataset_name=dataset_name
+    ).to_json()
   if 'condition_offsets' in dataset_config:
     c.infer_sets = get_infer_sets(
         num_timesteps_context=c.timesteps_input_infer
@@ -287,7 +310,10 @@ def get_config(
         + c.num_warmup_infer_steps,
         dataset_name=dataset_name,
     )
-  c.infer_batching_str = 'expand_dims(keys=("timeseries_input","timeseries_output","covariates_input","covariates_output"),axis=0)'  # 1x...  # pylint: disable=line-too-long
+  if poco_embeddings_series is None:
+    c.infer_batching_str = 'expand_dims(keys=("timeseries_input","timeseries_output","covariates_input","covariates_output"),axis=0)'  # 1x...  # pylint: disable=line-too-long
+  else:
+    c.infer_batching_str = 'expand_dims(keys=("timeseries_input","timeseries_output","covariates_input","covariates_output","poco_embeddings_input","poco_embeddings_output"),axis=0)'  # 1x...  # pylint: disable=line-too-long
   c.infer_save_array = True
   # {workdir}, {step} will be replaced, if present in prefix:
   c.infer_prefix = 'file://{workdir}/inference/step/{step}'

--- a/zapbench/ts_forecasting/configs/tide.py
+++ b/zapbench/ts_forecasting/configs/tide.py
@@ -69,7 +69,24 @@ def get_config(arg: str | None = None) -> mlc.ConfigDict:
   config = mlc.ConfigDict()
 
   config.arg = config_util.parse_arg(arg, **_ARGS)
-  config.update(common.get_config(**config.arg))
+  poco_embeddings_series = None
+  poco_embeddings_spec = None
+  if config.arg.use_poco_embeddings:
+    poco_embeddings_series = f'{config.arg.dataset_name}_poco_embeddings'
+    poco_embeddings_spec = data_utils.get_covariate_spec(
+        poco_embeddings_series, config.arg.dataset_name
+    )
+    if poco_embeddings_spec.rank != 2 or poco_embeddings_spec.shape[-1] != 8:
+      raise ValueError(
+          f'{poco_embeddings_series} must have shape (T, 8), got '
+          f'{poco_embeddings_spec.shape}.'
+      )
+  config.update(
+      common.get_config(
+          **config.arg, poco_embeddings_series=poco_embeddings_series
+      )
+  )
+  config.use_poco_embeddings = config.arg.use_poco_embeddings
 
   # NOTE: Tide was trained on 16 devices in parallel for the manuscript.
   config.per_device_batch_size = 1
@@ -79,16 +96,21 @@ def get_config(arg: str | None = None) -> mlc.ConfigDict:
   dynamic_covariates_spec = data_utils.get_covariate_spec(
       config.covariate_series, config.dataset_name)
 
-  config.covariates = (
+  covariates = [
       'covariates_static',
       'covariates_input',
       'covariates_output',
-  )
-  config.covariates_shapes = (
+  ]
+  covariates_shapes = [
       static_covariates_spec.shape,
       (1, config.timesteps_input, dynamic_covariates_spec.shape[-1]),
       (1, config.timesteps_output, dynamic_covariates_spec.shape[-1]),
-  )
+  ]
+  if poco_embeddings_spec is not None:
+    covariates.append('poco_covariates')
+    covariates_shapes.append((1, poco_embeddings_spec.shape[-1]))
+  config.covariates = tuple(covariates)
+  config.covariates_shapes = tuple(covariates_shapes)
   config.static_covariates_spec = static_covariates_spec.to_json()
 
   config.model_class = 'tide.Tide'

--- a/zapbench/ts_forecasting/data_source.py
+++ b/zapbench/ts_forecasting/data_source.py
@@ -197,6 +197,13 @@ class MergedTensorStoreTimeSeries:
     out = dict()
     for s in self.srcs:
       out.update(s[record_key])
+    if 'poco_embeddings_input' in out:
+      if 'poco_embeddings_output' not in out:
+        raise ValueError('POCO embedding source is missing its output window.')
+      out.pop('poco_embeddings_input')
+      # The first output row is the forecast origin s+c. The producer/store
+      # contract requires that row to use only history available before s+c.
+      out['poco_covariates'] = out.pop('poco_embeddings_output')[..., 0, :]
     return out
 
   def __repr__(self) -> str:
@@ -207,6 +214,9 @@ class MergedTensorStoreTimeSeries:
     out = dict()
     for s in self.srcs:
       out.update(s.item_shape)
+    if 'poco_embeddings_input' in out:
+      out.pop('poco_embeddings_input')
+      out['poco_covariates'] = (out.pop('poco_embeddings_output')[-1],)
     return out
 
 

--- a/zapbench/ts_forecasting/data_source_test.py
+++ b/zapbench/ts_forecasting/data_source_test.py
@@ -144,6 +144,81 @@ class DataSourceTest(parameterized.TestCase):
     for k in ('ds1_input', 'ds1_input', 'ds2_input', 'ds2_output', 'timestep'):
       assert k in batch
 
+  def test_merged_data_source_without_poco_is_unchanged(self):
+    covariates = data_source.TensorStoreTimeSeries(
+        self.default_config, prefix='covariates'
+    )
+    merged = data_source.MergedTensorStoreTimeSeries(covariates)
+
+    expected = covariates[3]
+    actual = merged[3]
+
+    self.assertEqual(actual.keys(), expected.keys())
+    self.assertEqual(merged.item_shape, covariates.item_shape)
+    for key in actual:
+      np.testing.assert_array_equal(actual[key], expected[key])
+
+  def test_merged_data_source_selects_poco_at_forecast_origin(self):
+    num_timesteps = 12
+    num_covariates = 3
+    num_poco_features = 8
+    timesteps_input = 4
+    timesteps_output = 2
+    covariate_values = np.arange(
+        num_timesteps * num_covariates, dtype=np.float32
+    ).reshape(num_timesteps, num_covariates)
+    poco_values = np.repeat(
+        np.arange(num_timesteps, dtype=np.float32)[:, np.newaxis],
+        num_poco_features,
+        axis=1,
+    )
+
+    def source(values: np.ndarray, prefix: str):
+      return data_source.TensorStoreTimeSeries(
+          data_source.TensorStoreTimeSeriesConfig(
+              input_spec={
+                  'driver': 'array',
+                  'dtype': 'float32',
+                  'array': values.tolist(),
+              },
+              timesteps_input=timesteps_input,
+              timesteps_output=timesteps_output,
+          ),
+          prefix=prefix,
+      )
+
+    merged = data_source.MergedTensorStoreTimeSeries(
+        source(covariate_values, 'covariates'),
+        source(poco_values, 'poco_embeddings'),
+    )
+    record_key = 3
+    batch = merged[record_key]
+
+    np.testing.assert_array_equal(
+        batch['covariates_input'],
+        covariate_values[record_key : record_key + timesteps_input],
+    )
+    np.testing.assert_array_equal(
+        batch['covariates_output'],
+        covariate_values[
+            record_key
+            + timesteps_input : record_key
+            + timesteps_input
+            + timesteps_output
+        ],
+    )
+    np.testing.assert_array_equal(
+        batch['poco_covariates'],
+        np.full(
+            (num_poco_features,),
+            record_key + timesteps_input,
+            dtype=np.float32,
+        ),
+    )
+    self.assertEqual(merged.item_shape['poco_covariates'], (num_poco_features,))
+    self.assertNotIn('poco_embeddings_input', batch)
+    self.assertNotIn('poco_embeddings_output', batch)
+
   def test_concatenated_data_source(self):
     ds1 = data_source.TensorStoreTimeSeries(self.default_config)
     ds2 = data_source.TensorStoreTimeSeries(self.default_config)

--- a/zapbench/ts_forecasting/input_pipeline_test.py
+++ b/zapbench/ts_forecasting/input_pipeline_test.py
@@ -15,12 +15,14 @@
 """Tests for input pipeline."""
 
 from typing import Any, Sequence
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
 import numpy as np
 from zapbench.ts_forecasting import input_pipeline
 from zapbench.ts_forecasting.configs import common
+from zapbench.ts_forecasting.configs import tide
 
 
 def build_placeholder_spec(shape: Sequence[int]) -> dict[str, Any]:
@@ -33,18 +35,99 @@ def build_placeholder_spec(shape: Sequence[int]) -> dict[str, Any]:
 
 
 def get_specs_for_test(
-    num_timesteps: int, num_features: int, num_dynamic_covariates: int
+    num_timesteps: int,
+    num_features: int,
+    num_dynamic_covariates: int,
+    num_poco_features: int = 0,
 ):
   """Returns specs for testing."""
-  return {
+  specs = {
       'covariates': build_placeholder_spec(
           (num_timesteps, num_dynamic_covariates)
       ),
       'timeseries': build_placeholder_spec((num_timesteps, num_features)),
   }
+  if num_poco_features:
+    specs['poco_embeddings'] = build_placeholder_spec(
+        (num_timesteps, num_poco_features)
+    )
+  return specs
 
 
 class InputPipelineTest(parameterized.TestCase):
+
+  def test_tide_config_without_poco_keeps_existing_sources_and_shapes(self):
+    config = tide.get_config('dataset_name=subject_01,seed=1')
+
+    self.assertFalse(config.use_poco_embeddings)
+    self.assertNotIn('poco_embeddings', config.infer_spec)
+    for specs in config.train_specs + config.val_specs:
+      self.assertNotIn('poco_embeddings', specs)
+    self.assertEqual(
+        config.covariates,
+        ('covariates_static', 'covariates_input', 'covariates_output'),
+    )
+    self.assertEqual(config.covariates_shapes[1][-1], 16)
+    self.assertEqual(config.covariates_shapes[2][-1], 16)
+    self.assertTrue(config.tide_config.ablate_past_covariates)
+
+  def test_tide_config_with_poco_adds_aligned_sources_and_shapes(self):
+    config = tide.get_config(
+        'dataset_name=subject_01,use_poco_embeddings=True,seed=1'
+    )
+
+    self.assertTrue(config.use_poco_embeddings)
+    self.assertIn('poco_embeddings', config.infer_spec)
+    self.assertNotIn(
+        'file:////', config.infer_spec['poco_embeddings']['kvstore']
+    )
+    for specs in config.train_specs + config.val_specs:
+      self.assertIn('poco_embeddings', specs)
+      self.assertEqual(
+          specs['poco_embeddings']['transform']['output'][0],
+          specs['covariates']['transform']['output'][0],
+      )
+    self.assertEqual(
+        config.covariates,
+        (
+            'covariates_static',
+            'covariates_input',
+            'covariates_output',
+            'poco_covariates',
+        ),
+    )
+    self.assertEqual(config.covariates_shapes[1][-1], 16)
+    self.assertEqual(config.covariates_shapes[2][-1], 16)
+    self.assertEqual(config.covariates_shapes[3], (1, 8))
+    self.assertTrue(config.tide_config.ablate_past_covariates)
+    self.assertIn('poco_embeddings_input', config.infer_batching_str)
+    self.assertIn('poco_embeddings_output', config.infer_batching_str)
+
+  def test_tide_config_with_poco_requires_registered_spec(self):
+    with self.assertRaisesRegex(
+        ValueError,
+        'janelia_pretrain_poco_embeddings not in dataset janelia_pretrain',
+    ):
+      tide.get_config(
+          'dataset_name=janelia_pretrain,use_poco_embeddings=True,seed=1'
+      )
+
+  @parameterized.named_parameters(
+      dict(testcase_name='wrong_rank', rank=3, shape=(100, 1, 8)),
+      dict(testcase_name='wrong_width', rank=2, shape=(100, 7)),
+  )
+  def test_tide_config_with_poco_requires_rank_two_width_eight(
+      self, rank: int, shape: tuple[int, ...]
+  ):
+    invalid_spec = mock.Mock(rank=rank, shape=shape)
+    with (
+        mock.patch(
+            'zapbench.ts_forecasting.configs.tide.data_utils.get_covariate_spec',
+            return_value=invalid_spec,
+        ),
+        self.assertRaisesRegex(ValueError, r'must have shape \(T, 8\)'),
+    ):
+      tide.get_config('dataset_name=subject_01,use_poco_embeddings=True,seed=1')
 
   @parameterized.named_parameters(
       dict(
@@ -59,6 +142,10 @@ class InputPipelineTest(parameterized.TestCase):
           testcase_name='repeated_specs',
           num_spec_repetitions=2,
       ),
+      dict(
+          testcase_name='poco_embeddings',
+          num_poco_features=8,
+      ),
   )
   def test_create_datasets(
       self,
@@ -67,12 +154,14 @@ class InputPipelineTest(parameterized.TestCase):
       num_timesteps: int = 1000,
       num_features: int = 16,
       num_dynamic_covariates: int = 2,
+      num_poco_features: int = 0,
       num_spec_repetitions: int = 1,
   ):
     specs = get_specs_for_test(
         num_timesteps=num_timesteps,
         num_features=num_features,
         num_dynamic_covariates=num_dynamic_covariates,
+        num_poco_features=num_poco_features,
     )
 
     config = common.get_config(
@@ -121,6 +210,16 @@ class InputPipelineTest(parameterized.TestCase):
         config.timesteps_output,
         num_dynamic_covariates,
     )
+    if num_poco_features:
+      self.assertEqual(
+          batch['poco_covariates'].shape,
+          (config.per_device_batch_size, num_poco_features),
+      )
+      np.testing.assert_array_equal(batch['poco_covariates'], 1)
+      self.assertNotIn('poco_embeddings_input', batch)
+      self.assertNotIn('poco_embeddings_output', batch)
+    else:
+      self.assertNotIn('poco_covariates', batch)
 
     val_iter = iter(val_loader)
     batch = next(val_iter)
@@ -147,6 +246,16 @@ class InputPipelineTest(parameterized.TestCase):
         config.timesteps_output,
         num_dynamic_covariates,
     )
+    if num_poco_features:
+      self.assertEqual(
+          batch['poco_covariates'].shape,
+          (config.per_device_batch_size, num_poco_features),
+      )
+      np.testing.assert_array_equal(batch['poco_covariates'], 1)
+      self.assertNotIn('poco_embeddings_input', batch)
+      self.assertNotIn('poco_embeddings_output', batch)
+    else:
+      self.assertNotIn('poco_covariates', batch)
 
   @parameterized.named_parameters(
       dict(
@@ -209,6 +318,48 @@ class InputPipelineTest(parameterized.TestCase):
         config.timesteps_output,
         num_dynamic_covariates,
     )
+
+  def test_inference_source_with_poco_batches_separate_origin_covariates(self):
+    num_timesteps = 100
+    num_features = 4
+    num_dynamic_covariates = 3
+    num_poco_features = 8
+    config = tide.get_config(
+        'dataset_name=subject_01,timesteps_input=4,'
+        'use_poco_embeddings=True,seed=1'
+    )
+    config.infer_spec = get_specs_for_test(
+        num_timesteps=num_timesteps,
+        num_features=num_features,
+        num_dynamic_covariates=num_dynamic_covariates,
+        num_poco_features=num_poco_features,
+    )
+
+    inference_source = input_pipeline.create_inference_source_with_transforms(
+        config
+    )
+    batch = inference_source[2]
+
+    self.assertEqual(
+        batch['covariates_input'].shape,
+        (
+            1,
+            config.timesteps_input,
+            num_dynamic_covariates,
+        ),
+    )
+    self.assertEqual(
+        batch['covariates_output'].shape,
+        (
+            1,
+            config.timesteps_output,
+            num_dynamic_covariates,
+        ),
+    )
+    self.assertEqual(batch['poco_covariates'].shape, (1, num_poco_features))
+    np.testing.assert_array_equal(batch['poco_covariates'], 1)
+    self.assertNotIn('poco_embeddings_input', batch)
+    self.assertNotIn('poco_embeddings_output', batch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Summary**
- Select the registered POCO store only when enabled across training, validation, restored inference, and index inference.
- Pass exactly one 8-dimensional vector at forecast origin s+c as TiDE fifth input.
- Leave ordinary past and future stimulus tensors unchanged and retain ablate_past_covariates=True for the matched comparison.
- Fail clearly for missing or malformed POCO specs.

**Verification**
- 34 focused synthetic pipeline tests
- All 14 POCO-enabled dataset configs parse
- Off path unchanged; on path selects s+c and preserves stimulus shapes
- Missing, wrong-rank, and wrong-width specs fail clearly

**Scope caveat**
Real POCO stores, train-only PCA and standardization, causal producer provenance, checkpoint compatibility, and pod accelerator validation remain separate prerequisites before execution.

**Stack base**
tide-poco-config